### PR TITLE
Add lru_cache support for versions under 3.8.

### DIFF
--- a/appdata/utils.py
+++ b/appdata/utils.py
@@ -3,12 +3,12 @@ from pathlib import Path
 from typing import Optional
 
 
-@lru_cache
+@lru_cache()
 def get_home_folder():
     return Path.home().absolute()
 
 
-@lru_cache
+@lru_cache()
 def prepare_ext(ext: Optional[str]):
     if ext and len(ext) != 0:
         while ext.startswith('..'):


### PR DESCRIPTION
lru_cache requires direct call `@lru_cache()` to work correctly with versions before 3.8.

PR fixes the following issue - https://github.com/VoIlAlex/appdata/issues/2.